### PR TITLE
WIP: NEUBURG-101 allow multiple kinds of form data

### DIFF
--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -1,7 +1,10 @@
 // @flow
 
 import mongoose from 'mongoose'
-import forms from './forms'
+
+const formDataSchema = mongoose.Schema({})
+
+export const FormData = mongoose.model('FormData', formDataSchema)
 
 const offerSchema = mongoose.Schema({
   email: {
@@ -35,7 +38,7 @@ const offerSchema = mongoose.Schema({
   },
   formData: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: Array.from(Object.keys(forms)), // Must be one of the forms defined in forms.js
+    ref: 'FormData',
     required: [true, 'Missing form data']
   }
 })

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -5,18 +5,16 @@ import testumgebungForm from './forms/testumgebungForm'
 import mongoose from 'mongoose'
 import cityConfigs from '../cities/cityConfigs'
 import {difference, get, pull, set} from 'lodash'
-import Offer from './Offer'
+import Offer, {FormData} from './Offer'
 
 type AllFormsType = | typeof neuburgForm
 
-const schemaOptions = {strict: 'throw'}
-
-const Neuburg = mongoose.model(
-  cityConfigs.neuburgschrobenhausenwohnraum.cmsName, mongoose.Schema(neuburgForm, schemaOptions)
+const Neuburg = FormData.discriminator(
+  cityConfigs.neuburgschrobenhausenwohnraum.cmsName, new mongoose.Schema(neuburgForm)
 )
 
-const Testumgebung = mongoose.model(
-  cityConfigs.testumgebungwohnraum.cmsName, mongoose.Schema(testumgebungForm, schemaOptions)
+const Testumgebung = FormData.discriminator(
+  cityConfigs.testumgebungwohnraum.cmsName, new mongoose.Schema(testumgebungForm)
 )
 
 const addNotIncludedFor = (offer: Offer, form: AllFormsType, names: Array<string>, omit: Array<string>) => {

--- a/src/services/ErrorService.js
+++ b/src/services/ErrorService.js
@@ -25,6 +25,7 @@ export default class ErrorService {
 
   createInternalServerErrorResponse (error: Error): string | ErrorResponse {
     this.logger.error(error.toString())
+    this.logger.error(error.stack)
     if (develop) {
       return error.message
     } else {


### PR DESCRIPTION
@NKlug Please take a look at this PR.
I'm not sure when it comes to mongoose things, but I'm pretty sure, that we can't just put an array of schemas/models in the `ref` field.
Instead we could use the .discriminator thingy, but I'm not sure if it's that easy as in the PR (but works at first sight)...
Now we also need to check, if we need to migrate the current db...

If you want you could work on this branch and / or assign yourself to this task, since you're probably more into mongoose...